### PR TITLE
EDIT: changed minimum VSCode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "net-core-ntu-extension-pack",
   "displayName": ".NET Core NTU Extension Pack",
   "description": "This is a collection of relevant VS Code extensions for ASP.NET Core. This list is prepared for the Internet Application Programming module at Nottingham Trent University (NTU)",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "salisuwy",
 	"private": true,
 	"license": "MIT",
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.59.0"
   },
   "categories": [
     "Extension Packs"


### PR DESCRIPTION
EDIT: changed minimum VSCode version to allow installation on Software Hub version of VSCode

EDIT: updated version of package to 0.0.2

have confirmed that the package still installs when the minimum version is lowered to 1.59.0 for Software Hub version of VSCode.